### PR TITLE
Add missing parameters to resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 ## [Unreleased]
 ### Added
 - "payment" account type for Pix related resources
+- missing parameters to Boleto, BrcodePayment, Deposit, DictKey, Event, Invoice, Transfer and Workspace resources
 
 ### Fixed
 - special characters in brcodePreview query

--- a/lib/boleto/boleto.rb
+++ b/lib/boleto/boleto.rb
@@ -38,15 +38,17 @@ module StarkBank
   # - fee [integer, default nil]: fee charged when Boleto is paid. ex: 200 (= R$ 2.00)
   # - line [string, default nil]: generated Boleto line for payment. ex: '34191.09008 63571.277308 71444.640008 5 81960000000062'
   # - bar_code [string, default nil]: generated Boleto bar-code for payment. ex: '34195819600000000621090063571277307144464000'
+  # - transaction_ids [list of strings, default nil]: ledger transaction ids linked to this boleto. ex: ['19827356981273']
   # - status [string, default nil]: current Boleto status. ex: 'registered' or 'paid'
   # - created [DateTime, default nil]: creation datetime for the Boleto. ex: DateTime.new(2020, 3, 10, 10, 30, 0, 0)
+  # - our_number [string, default nil]: Reference number registered at the settlement bank. ex:'10131474'
   class Boleto < StarkBank::Utils::Resource
-    attr_reader :amount, :name, :tax_id, :street_line_1, :street_line_2, :district, :city, :state_code, :zip_code, :due, :fine, :interest, :overdue_limit, :receiver_name, :receiver_tax_id, :tags, :descriptions, :discounts, :id, :fee, :line, :bar_code, :status, :created
+    attr_reader :amount, :name, :tax_id, :street_line_1, :street_line_2, :district, :city, :state_code, :zip_code, :due, :fine, :interest, :overdue_limit, :receiver_name, :receiver_tax_id, :tags, :descriptions, :discounts, :id, :fee, :line, :bar_code, :status, :transaction_ids, :created, :our_number
     def initialize(
       amount:, name:, tax_id:, street_line_1:, street_line_2:, district:, city:, state_code:, zip_code:,
       due: nil, fine: nil, interest: nil, overdue_limit: nil, receiver_name: nil, receiver_tax_id: nil,
       tags: nil, descriptions: nil, discounts: nil, id: nil, fee: nil, line: nil, bar_code: nil,
-      status: nil, created: nil
+      status: nil, transaction_ids: nil, created: nil, our_number: nil
     )
       super(id)
       @amount = amount
@@ -71,7 +73,9 @@ module StarkBank
       @line = line
       @bar_code = bar_code
       @status = status
+      @transaction_ids = transaction_ids
       @created = StarkBank::Utils::Checks.check_datetime(created)
+      @our_number = our_number
     end
 
     # # Create Boletos
@@ -114,8 +118,8 @@ module StarkBank
     # - id [string]: object unique id. ex: '5656565656565656'
     #
     # ## Parameters (optional):
-    # - layout [string]: Layout specification. Available options are "default" and "booklet"
-    # - hidden_fields [list of strings, default nil]: List of string fields to be hidden in Boleto pdf. ex: ["customerAddress"]
+    # - layout [string]: Layout specification. Available options are 'default' and 'booklet'
+    # - hidden_fields [list of strings, default nil]: List of string fields to be hidden in Boleto pdf. ex: ['customerAddress']
     # - user [Organization/Project object]: Organization or Project object. Not necessary if StarkBank.user was set before function call
     #
     # ## Return:
@@ -198,7 +202,9 @@ module StarkBank
             line: json['line'],
             bar_code: json['bar_code'],
             status: json['status'],
-            created: json['created']
+            transaction_ids: json['transaction_ids'],
+            created: json['created'],
+            our_number: json['our_number']
           )
         }
       }

--- a/lib/brcode_payment/brcode_payment.rb
+++ b/lib/brcode_payment/brcode_payment.rb
@@ -12,9 +12,9 @@ module StarkBank
   # to the Stark Bank API and returns the list of created objects.
   #
   # ## Parameters (required):
-  # - brcode [string]: String loaded directly from the QRCode or copied from the invoice. ex: "00020126580014br.gov.bcb.pix0136a629532e-7693-4846-852d-1bbff817b5a8520400005303986540510.005802BR5908T'Challa6009Sao Paulo62090505123456304B14A"
-  # - tax_id [string]: receiver tax ID (CPF or CNPJ) with or without formatting. ex: "01234567890" or "20.018.183/0001-80"
-  # - description [string]: Text to be displayed in your statement (min. 10 characters). ex: "payment ABC"
+  # - brcode [string]: String loaded directly from the QRCode or copied from the invoice. ex: '00020126580014br.gov.bcb.pix0136a629532e-7693-4846-852d-1bbff817b5a8520400005303986540510.005802BR5908T'Challa6009Sao Paulo62090505123456304B14A'
+  # - tax_id [string]: receiver tax ID (CPF or CNPJ) with or without formatting. ex: '01234567890' or '20.018.183/0001-80'
+  # - description [string]: Text to be displayed in your statement (min. 10 characters). ex: 'payment ABC'
   #
   # ## Parameters (conditionally required):
   # - amount [int, default nil]: If the BRCode does not provide an amount, this parameter is mandatory, else it is optional. ex: 23456 (= R$ 234.56)
@@ -24,15 +24,17 @@ module StarkBank
   # - tags [list of strings, default nil]: list of strings for tagging
   #
   # ## Attributes (return-only):
-  # - id [string, default nil]: unique id returned when payment is created. ex: "5656565656565656"
-  # - status [string, default nil]: current payment status. ex: "success" or "failed"
-  # - type [string, default nil]: brcode type. ex: "static" or "dynamic"
+  # - id [string, default nil]: unique id returned when payment is created. ex: '5656565656565656'
+  # - name [string, nil]: receiver name. ex: 'Jon Snow'
+  # - status [string, default nil]: current payment status. ex: 'success' or 'failed'
+  # - type [string, default nil]: brcode type. ex: 'static' or 'dynamic'
+  # - transaction_ids [list of strings, default nil]: ledger transaction ids linked to this payment. ex: ['19827356981273']
   # - fee [integer, default nil]: fee charged when the brcode payment is created. ex: 200 (= R$ 2.00)
   # - updated [datetime.datetime, default nil]: latest update datetime for the payment. ex: datetime.datetime(2020, 3, 10, 10, 30, 0, 0)
   # - created [datetime.datetime, default nil]: creation datetime for the payment. ex: datetime.datetime(2020, 3, 10, 10, 30, 0, 0)
   class BrcodePayment < StarkBank::Utils::Resource
-    attr_reader :brcode, :tax_id, :description, :amount, :scheduled, :tags, :id, :status, :type, :fee, :updated, :created
-    def initialize(brcode:, tax_id:, description:, amount: nil, scheduled: nil, tags: nil, id: nil, status: nil, type: nil, fee: nil, updated: nil, created: nil)
+    attr_reader :brcode, :tax_id, :description, :amount, :scheduled, :tags, :id, :name, :status, :type, :transaction_ids, :fee, :updated, :created
+    def initialize(brcode:, tax_id:, description:, amount: nil, scheduled: nil, tags: nil, id: nil, name: nil, status: nil, type: nil, transaction_ids: nil, fee: nil, updated: nil, created: nil)
       super(id)
       @brcode = brcode
       @tax_id = tax_id
@@ -40,8 +42,10 @@ module StarkBank
       @amount = amount
       @scheduled = StarkBank::Utils::Checks.check_date_or_datetime(scheduled)
       @tags = tags
+      @name = name
       @status = status
       @type = type
+      @transaction_ids = transaction_ids
       @fee = fee
       @updated = StarkBank::Utils::Checks.check_datetime(updated)
       @created = StarkBank::Utils::Checks.check_datetime(created)
@@ -154,8 +158,10 @@ module StarkBank
             scheduled: json['scheduled'],
             tags: json['tags'],
             id: json['id'],
+            name: json['name'],
             status: json['status'],
             type: json['type'],
+            transaction_ids: json['transaction_ids'],
             fee: json['fee'],
             updated: json['updated'],
             created: json['created']

--- a/lib/deposit/deposit.rb
+++ b/lib/deposit/deposit.rb
@@ -16,6 +16,7 @@ module StarkBank
   # - bank_code [string]: payer bank code in Brazil. ex: '20018183' or '341'
   # - branch_code [string]: payer bank account branch. ex: '1357-9's
   # - account_number [string]: payer bank account number. ex: '876543-2'
+  # - account_type [string]: payer bank account type. ex: 'checking'
   # - amount [integer]: Deposit value in cents. ex: 1234 (= R$ 12.34)
   # - type [string]: Type of settlement that originated the deposit. ex: 'pix' or 'ted'
   # - status [string]: current Deposit status. ex: 'created'
@@ -25,10 +26,10 @@ module StarkBank
   # - created [datetime.datetime]: creation datetime for the Deposit. ex: datetime.datetime(2020, 12, 10, 10, 30, 0, 0)
   # - updated [datetime.datetime]: latest update datetime for the Deposit. ex: datetime.datetime(2020, 12, 10, 10, 30, 0, 0)
   class Deposit < StarkBank::Utils::Resource
-    attr_reader :id, :name, :tax_id, :bank_code, :branch_code, :account_number, :amount, :type, :status, :tags, :fee, :transaction_ids, :created, :updated
+    attr_reader :id, :name, :tax_id, :bank_code, :branch_code, :account_number, :account_type, :amount, :type, :status, :tags, :fee, :transaction_ids, :created, :updated
     def initialize(
-      id:, name:, tax_id:, bank_code:, branch_code:, account_number:, amount:, type:, status:, tags:, fee:,
-      transaction_ids:, created:, updated:
+      id:, name:, tax_id:, bank_code:, branch_code:, account_number:, account_type:, amount:, type:, 
+      status:, tags:, fee:, transaction_ids:, created:, updated:
     )
       super(id)
       @name = name
@@ -36,6 +37,7 @@ module StarkBank
       @bank_code = bank_code
       @branch_code = branch_code
       @account_number = account_number
+      @account_type = account_type
       @amount = amount
       @type = type
       @status = status
@@ -105,6 +107,7 @@ module StarkBank
             bank_code: json['bank_code'],
             branch_code: json['branch_code'],
             account_number: json['account_number'],
+            account_type: json['account_type'],
             amount: json['amount'],
             type: json['type'],
             status: json['status'],

--- a/lib/dict_key/dict_key.rb
+++ b/lib/dict_key/dict_key.rb
@@ -17,6 +17,7 @@ module StarkBank
   # - name [string, default nil]: account owner full name. ex: 'Tony Stark'
   # - tax_id [string, default nil]: key owner tax ID (CNPJ or masked CPF). ex: '***.345.678-**' or '20.018.183/0001-80'
   # - owner_type [string, default nil]: DICT key owner type. ex 'naturalPerson' or 'legalPerson'
+  # - bank_name [string, default nil]: bank name associated with the DICT key. ex: 'Stark Bank'
   # - ispb [string, default nil]: bank ISPB associated with the DICT key. ex: '20018183'
   # - branch_code [string, default nil]: bank account branch code associated with the DICT key. ex: '9585'
   # - account_number [string, default nil]: bank account number associated with the DICT key. ex: '9828282578010513'
@@ -26,16 +27,17 @@ module StarkBank
   # - owned [DateTime or string, default nil]: datetime since when the current owner hold this DICT key. ex : '2020-11-05T14:55:08.812665+00:00'
   # - created [DateTime or string, default nil]: creation datetime for the DICT key. ex: '2020-03-10 10:30:00.000'
   class DictKey < StarkBank::Utils::Resource
-    attr_reader :id, :type, :name, :tax_id, :owner_type, :ispb, :branch_code, :account_number, :account_type, :status, :account_created, :owned, :created
+    attr_reader :id, :type, :name, :tax_id, :owner_type, :bank_name, :ispb, :branch_code, :account_number, :account_type, :status, :account_created, :owned, :created
     def initialize(
-      id:, type:, name:, tax_id:, owner_type:, ispb:, branch_code:, account_number:, account_type:,
-      status:, account_created:, owned:, created:
+      id:, type:, name:, tax_id:, owner_type:, bank_name:, ispb:, branch_code:, account_number:, 
+      account_type:, status:, account_created:, owned:, created:
     )
       super(id)
       @type = type
       @name = name
       @tax_id = tax_id
       @owner_type = owner_type
+      @bank_name = bank_name
       @ispb = ispb
       @branch_code = branch_code
       @account_number = account_number
@@ -102,6 +104,7 @@ module StarkBank
             name: json['name'],
             tax_id: json['tax_id'],
             owner_type: json['owner_type'],
+            bank_name: json['bank_name'],
             ispb: json['ispb'],
             branch_code: json['branch_code'],
             account_number: json['account_number'],

--- a/lib/event/event.rb
+++ b/lib/event/event.rb
@@ -28,13 +28,15 @@ module StarkBank
   # - log [Log]: a Log object from one the subscription services (TransferLog, InvoiceLog, BoletoLog, BoletoPaymentlog or UtilityPaymentLog)
   # - created [DateTime]: creation datetime for the notification event. ex: DateTime.new(2020, 3, 10, 10, 30, 0, 0)
   # - is_delivered [bool]: true if the event has been successfully delivered to the user url. ex: False
+  # - workspace_id [string]: ID of the Workspace that generated this event. Mostly used when multiple Workspaces have Webhooks registered to the same endpoint. ex: '4545454545454545'
   # - subscription [string]: service that triggered this event. ex: 'transfer', 'utility-payment'
   class Event < StarkBank::Utils::Resource
-    attr_reader :id, :log, :created, :is_delivered, :subscription
-    def initialize(id:, log:, created:, is_delivered:, subscription:)
+    attr_reader :id, :log, :created, :is_delivered, :workspace_id, :subscription
+    def initialize(id:, log:, created:, is_delivered:, workspace_id:, subscription:)
       super(id)
       @created = StarkBank::Utils::Checks.check_datetime(created)
       @is_delivered = is_delivered
+      @workspace_id = workspace_id
       @subscription = subscription
 
       resource = {
@@ -185,6 +187,7 @@ module StarkBank
               log: json['log'],
               created: json['created'],
               is_delivered: json['is_delivered'],
+              workspace_id: json['workspace_id'],
               subscription: json['subscription']
             )
           }

--- a/lib/invoice/invoice.rb
+++ b/lib/invoice/invoice.rb
@@ -26,6 +26,8 @@ module StarkBank
   # - tags [list of strings, default nil]: list of strings for tagging
   #
   # ## Attributes (return-only):
+  # - pdf [string, default nil]: public Invoice PDF URL. ex: 'https://invoice.starkbank.com/pdf/d454fa4e524441c1b0c1a729457ed9d8'
+  # - link [string, default nil]: public Invoice webpage URL. ex: 'https://my-workspace.sandbox.starkbank.com/invoicelink/d454fa4e524441c1b0c1a729457ed9d8'
   # - id [string, default nil]: unique id returned when Invoice is created. ex: '5656565656565656'
   # - nominal_amount [integer, default nil]: Invoice emission value in cents (will change if invoice is updated, but not if it's paid). ex: 400000
   # - fine_amount [integer, default nil]: Invoice fine value calculated over nominal_amount. ex: 20000
@@ -37,11 +39,11 @@ module StarkBank
   # - created [DateTime, default nil]: creation datetime for the Invoice. ex: DateTime.new(2020, 3, 10, 10, 30, 0, 0)
   # - updated [DateTime, default nil]: latest update datetime for the Invoice. ex: DateTime.new(2020, 3, 10, 10, 30, 0, 0)
   class Invoice < StarkBank::Utils::Resource
-    attr_reader :amount, :tax_id, :name, :due, :expiration, :fine, :interest, :discounts, :tags, :descriptions, :nominal_amount, :fine_amount, :interest_amount, :discount_amount, :id, :brcode, :fee, :status, :created, :updated
+    attr_reader :amount, :tax_id, :name, :due, :expiration, :fine, :interest, :discounts, :tags, :pdf, :link, :descriptions, :nominal_amount, :fine_amount, :interest_amount, :discount_amount, :id, :brcode, :fee, :status, :transaction_ids, :created, :updated
     def initialize(
       amount:, tax_id:, name:, due: nil, expiration: nil, fine: nil, interest: nil, discounts: nil,
-      tags: nil, descriptions: nil, nominal_amount: nil, fine_amount: nil, interest_amount: nil,
-      discount_amount: nil, id: nil, brcode: nil, fee: nil, status: nil, created: nil, updated: nil
+      tags: nil, pdf: nil, link: nil, descriptions: nil, nominal_amount: nil, fine_amount: nil, interest_amount: nil,
+      discount_amount: nil, id: nil, brcode: nil, fee: nil, status: nil, transaction_ids: nil, created: nil, updated: nil
     )
       super(id)
       @amount = amount
@@ -53,6 +55,8 @@ module StarkBank
       @interest = interest
       @discounts = discounts
       @tags = tags
+      @pdf = pdf
+      @link = link
       @descriptions = descriptions
       @nominal_amount = nominal_amount
       @fine_amount = fine_amount
@@ -61,6 +65,7 @@ module StarkBank
       @brcode = brcode
       @fee = fee
       @status = status
+      @transaction_ids = transaction_ids
       @updated = StarkBank::Utils::Checks.check_datetime(updated)
       @created = StarkBank::Utils::Checks.check_datetime(created)
     end
@@ -193,6 +198,8 @@ module StarkBank
             interest: json['interest'],
             discounts: json['discounts'],
             tags: json['tags'],
+            pdf: json['pdf'],
+            link: json['link'],
             descriptions: json['descriptions'],
             nominal_amount: json['nominal_amount'],
             fine_amount: json['fine_amount'],
@@ -201,6 +208,7 @@ module StarkBank
             brcode: json['brcode'],
             fee: json['fee'],
             status: json['status'],
+            transaction_ids: json['transaction_ids'],
             updated: json['updated'],
             created: json['created'],
           )

--- a/lib/transfer/transfer.rb
+++ b/lib/transfer/transfer.rb
@@ -23,6 +23,7 @@ module StarkBank
   # - account_type [string, default 'checking']: receiver bank account type. This parameter only has effect on Pix Transfers. ex: 'checking', 'savings', 'salary' or 'payment'
   # - external_id [string, default nil]: url safe string that must be unique among all your transfers. Duplicated external_ids will cause failures. By default, this parameter will block any transfer that repeats amount and receiver information on the same date. ex: 'my-internal-id-123456'
   # - scheduled [string, default now]: datetime when the transfer will be processed. May be pushed to next business day if necessary. ex: DateTime.new(2020, 3, 11, 8, 13, 12, 11)
+  # - description [string, default nil]: optional description to override default description to be shown in the bank statement. ex: 'Payment for service #1234'
   # - tags [list of strings]: list of strings for reference when searching for transfers. ex: ['employees', 'monthly']
   #
   # ## Attributes (return-only):
@@ -33,8 +34,8 @@ module StarkBank
   # - created [DateTime, default nil]: creation datetime for the transfer. ex: DateTime.new(2020, 3, 10, 10, 30, 0, 0)
   # - updated [DateTime, default nil]: latest update datetime for the transfer. ex: DateTime.new(2020, 3, 10, 10, 30, 0, 0)
   class Transfer < StarkBank::Utils::Resource
-    attr_reader :amount, :name, :tax_id, :bank_code, :branch_code, :account_number, :account_type, :external_id, :scheduled, :transaction_ids, :fee, :tags, :status, :id, :created, :updated
-    def initialize(amount:, name:, tax_id:, bank_code:, branch_code:, account_number:, account_type: nil, external_id: nil, scheduled: nil, transaction_ids: nil, fee: nil, tags: nil, status: nil, id: nil, created: nil, updated: nil)
+    attr_reader :amount, :name, :tax_id, :bank_code, :branch_code, :account_number, :account_type, :external_id, :scheduled, :description, :transaction_ids, :fee, :tags, :status, :id, :created, :updated
+    def initialize(amount:, name:, tax_id:, bank_code:, branch_code:, account_number:, account_type: nil, external_id: nil, scheduled: nil, description: nil, transaction_ids: nil, fee: nil, tags: nil, status: nil, id: nil, created: nil, updated: nil)
       super(id)
       @amount = amount
       @name = name
@@ -45,6 +46,7 @@ module StarkBank
       @account_type = account_type
       @external_id = external_id
       @scheduled = StarkBank::Utils::Checks.check_date_or_datetime(scheduled)
+      @description = description
       @transaction_ids = transaction_ids
       @fee = fee
       @tags = tags
@@ -168,6 +170,7 @@ module StarkBank
             account_type: json['account_type'],
             external_id: json['external_id'],
             scheduled: json['scheduled'],
+            description: json['description'],
             transaction_ids: json['transaction_ids'],
             fee: json['fee'],
             tags: json['tags'],

--- a/lib/workspace/workspace.rb
+++ b/lib/workspace/workspace.rb
@@ -15,14 +15,18 @@ module StarkBank
   # - username [string]: Simplified name to define the workspace URL. This name must be unique across all Stark Bank Workspaces. Ex: 'starkbankworkspace'
   # - name [string]: Full name that identifies the Workspace. This name will appear when people access the Workspace on our platform, for example. Ex: 'Stark Bank Workspace'
   #
+  # ## Parameters (optional):
+  # - allowed_tax_ids [list of strings]: list of tax IDs that will be allowed to send Deposits to this Workspace. ex: ['012.345.678-90', '20.018.183/0001-80']
+  #
   # ## Attributes:
   # - id [string, default nil]: unique id returned when the workspace is created. ex: '5656565656565656'
   class Workspace < StarkBank::Utils::Resource
-    attr_reader :username, :name, :id
-    def initialize(username:, name:, id: nil)
+    attr_reader :username, :name, :allowed_tax_ids, :id
+    def initialize(username:, name:, allowed_tax_ids: nil, id: nil)
       super(id)
       @username = username
       @name = name
+      @allowed_tax_ids = allowed_tax_ids
     end
 
     # # Create Workspace
@@ -38,8 +42,8 @@ module StarkBank
     #
     # ## Return:
     # - Workspace object with updated attributes
-    def self.create(username:, name:, user: nil)
-      StarkBank::Utils::Rest.post_single(entity: Workspace.new(username: username, name: name), user: user, **resource)
+    def self.create(username:, name:, user: nil, allowed_tax_ids: nil)
+      StarkBank::Utils::Rest.post_single(entity: Workspace.new(username: username, name: name, allowed_tax_ids: allowed_tax_ids), user: user, **resource)
     end
 
     # # Retrieve a specific Workspace
@@ -83,7 +87,8 @@ module StarkBank
           Workspace.new(
             id: json['id'],
             username: json['username'],
-            name: json['name']
+            name: json['name'],
+            allowed_tax_ids: json['allowed_tax_ids']
           )
         }
       }

--- a/test/example_generator.rb
+++ b/test/example_generator.rb
@@ -95,7 +95,8 @@ class ExampleGenerator
     uuid = SecureRandom.uuid
     StarkBank::Workspace.new(
       username: "starkv2-#{uuid}",
-      name: "Stark V2: #{uuid}"
+      name: "Stark V2: #{uuid}",
+      allowed_tax_ids: ['20.018.183/0001-80']
     )
   end
 

--- a/test/starkbank/test_workspace.rb
+++ b/test/starkbank/test_workspace.rb
@@ -6,7 +6,7 @@ require_relative('../example_generator.rb')
 describe(StarkBank::Workspace, '#workspace') do
   it 'create' do
     workspace = ExampleGenerator.workspace_example
-    workspace = StarkBank::Workspace.create(username: workspace.username, name: workspace.name, user: ExampleGenerator.organization_example)
+    workspace = StarkBank::Workspace.create(username: workspace.username, name: workspace.name, allowed_tax_ids: workspace.allowed_tax_ids, user: ExampleGenerator.organization_example)
     expect(workspace.id).wont_be_nil
     expect(workspace.username).wont_be_nil
     expect(workspace.name).wont_be_nil


### PR DESCRIPTION
# Add missing parameters to Boleto, BrcodePayment, Deposit, DictKey and Invoice resources

## Boleto:
- transaction_ids
- our_number

## BrcodePayment:
- name
- transaction_ids

## Deposit:
- account_type

## DictKey:
- bank_name

## Event:
- workspace_id

## Invoice:
- pdf
- link
- transaction_ids

## Transfer:
- description