### PR TITLE
Changed create method from Transaction resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 
 
 ## [Unreleased]
+### Changed
+- The create method from the Transaction resource is now deprecated
 
 ## [2.14.0] - 2025-07-30
 ### Added

--- a/lib/transaction/transaction.rb
+++ b/lib/transaction/transaction.rb
@@ -47,6 +47,7 @@ module StarkBank
       @created = StarkCore::Utils::Checks.check_datetime(created)
     end
 
+    # # DEPRECATED: Function deprecated since v2.15.0
     # # Create Transactions
     #
     # Send a list of Transaction objects for creation in the Stark Bank API
@@ -60,7 +61,7 @@ module StarkBank
     # ## Return:
     # - list of Transaction objects with updated attributes
     def self.create(transactions, user: nil)
-      StarkBank::Utils::Rest.post(entities: transactions, user: user, **resource)
+      raise "Function deprecated since v2.15.0"
     end
 
     # # Retrieve a specific Transaction

--- a/test/starkbank/test_transaction.rb
+++ b/test/starkbank/test_transaction.rb
@@ -5,13 +5,16 @@ require_relative('../example_generator')
 require('date')
 
 describe(StarkBank::Transaction, '#transaction#') do
-  it 'query' do
+  it 'query and get' do
     after = Date.today - 30
     transactions = StarkBank::Transaction.query(limit: 10, after: after).to_a
     expect(transactions.length).must_equal(10)
     transactions.each do |transaction|
       expect(transaction.id).wont_be_nil
       expect(transaction.created).must_be(:>=, after)
+      get_transaction = StarkBank::Transaction.get(transaction.id)
+      expect(transaction.id).must_equal(get_transaction.id)
+      expect(transaction.amount).must_equal(get_transaction.amount)
     end
   end
 
@@ -48,13 +51,10 @@ describe(StarkBank::Transaction, '#transaction#') do
     expect(ids.length).must_equal(10)
   end
 
-  it 'create and get' do
+  it 'create' do
     transaction = ExampleGenerator.transaction_example
-    create_transaction = StarkBank::Transaction.create([transaction])[0]
-    expect(-transaction.amount).must_equal(create_transaction.amount)
-    get_transaction = StarkBank::Transaction.get(create_transaction.id)
-    expect(create_transaction.id).must_equal(get_transaction.id)
-    expect(create_transaction.amount).must_equal(get_transaction.amount)
+    error = expect { StarkBank::Transaction.create([transaction])[0] }.must_raise(RuntimeError)
+    expect(error.message).must_equal("Function deprecated since v2.15.0")
   end
 
 end


### PR DESCRIPTION
### Changed
- The create method from the Transaction resource is now deprecated